### PR TITLE
Syntactically valid algorithm names

### DIFF
--- a/aslib/R/parseASScenario.R
+++ b/aslib/R/parseASScenario.R
@@ -96,6 +96,7 @@ parseASScenario = function(path) {
   algorithm.feature.runstatus = readRunstatus(path = path, filename = "algorithm_feature_runstatus.arff", 
                 statusLevels = c("ok", "timeout", "memout", "crash", "other", "unknown"), 
                 fsteps = algo_fsteps, sortBy = c("algorithm", "repetition"), ignoreExists = TRUE)
+  algorithm.feature.runstatus$algorithm = make.names(algorithm.feature.runstatus$algorithm)
 
   ### build feature.costs
   costfile = file.path(path, "feature_costs.arff")
@@ -105,6 +106,7 @@ parseASScenario = function(path) {
   algorithm.costfile = file.path(path, "algorithm_feature_costs.arff")
   algorithm.feature.costs = readCosts(filename = algorithm.costfile, 
                                      fsteps = fsteps, sortBy = c("algorithm", "repetition"))
+  algorithm.feature.costs$algorithm = make.names(algorithm.feature.costs$algorithm)
 
   ### build feature.values
   feature.values = readFeatureValues(path = path, 
@@ -119,6 +121,7 @@ parseASScenario = function(path) {
               sortBy = c("algorithm", "repetition"), 
               featureSort = c(desc$algorithm_features_deterministic, desc$algorithm_features_stochastic), 
               ignoreExists = TRUE)
+  algorithm.feature.values$algorithm = make.names(algorithm.feature.values$algorithm)
 
   algo.runs = read.arff(file.path(path, "algorithm_runs.arff"))
   colnames(algo.runs) = make.names(colnames(algo.runs))

--- a/aslib/R/parseASScenario.R
+++ b/aslib/R/parseASScenario.R
@@ -96,7 +96,9 @@ parseASScenario = function(path) {
   algorithm.feature.runstatus = readRunstatus(path = path, filename = "algorithm_feature_runstatus.arff", 
                 statusLevels = c("ok", "timeout", "memout", "crash", "other", "unknown"), 
                 fsteps = algo_fsteps, sortBy = c("algorithm", "repetition"), ignoreExists = TRUE)
-  algorithm.feature.runstatus$algorithm = make.names(algorithm.feature.runstatus$algorithm)
+  if (!is.null(algorithm.feature.runstatus)) {
+    algorithm.feature.runstatus$algorithm = make.names(algorithm.feature.runstatus$algorithm)
+  }
 
   ### build feature.costs
   costfile = file.path(path, "feature_costs.arff")
@@ -106,7 +108,9 @@ parseASScenario = function(path) {
   algorithm.costfile = file.path(path, "algorithm_feature_costs.arff")
   algorithm.feature.costs = readCosts(filename = algorithm.costfile, 
                                      fsteps = fsteps, sortBy = c("algorithm", "repetition"))
-  algorithm.feature.costs$algorithm = make.names(algorithm.feature.costs$algorithm)
+  if (!is.null(algorithm.feature.costs)) {
+    algorithm.feature.costs$algorithm = make.names(algorithm.feature.costs$algorithm)
+  }
 
   ### build feature.values
   feature.values = readFeatureValues(path = path, 
@@ -121,7 +125,9 @@ parseASScenario = function(path) {
               sortBy = c("algorithm", "repetition"), 
               featureSort = c(desc$algorithm_features_deterministic, desc$algorithm_features_stochastic), 
               ignoreExists = TRUE)
-  algorithm.feature.values$algorithm = make.names(algorithm.feature.values$algorithm)
+  if (!is.null(algorithm.feature.values)) {
+    algorithm.feature.values$algorithm = make.names(algorithm.feature.values$algorithm)
+  }
 
   algo.runs = read.arff(file.path(path, "algorithm_runs.arff"))
   colnames(algo.runs) = make.names(colnames(algo.runs))


### PR DESCRIPTION
Running `make.names` on algorithm names to make sure they are valid. `make.names` is already used everywhere else. This just double checks that algorithm names for new features are valid as well.